### PR TITLE
upgrade Solr to v9.1.0

### DIFF
--- a/solr/deployment.yml
+++ b/solr/deployment.yml
@@ -66,9 +66,15 @@ spec:
   replicas: 1
   solrImage:
     repository: solr
-    tag: 8.11.1
+    tag: 9.1.0
   solrJavaMem: -Xms3g -Xmx3g
-  solrOpts: "-Dlog4j2.formatMsgNoLookups=true -Dsolr.cloud.client.stallTime=30000 -Dsolr.environment=dev,label=iati-dev,color=aqua"
+  solrOpts: >
+    -Dsolr.cloud.client.stallTime=30000 
+    -Dsolr.environment=dev,label=iati-dev,color=aqua
+    -Dsolr.modules=scripting
+    -Dsolrxsltloc=solr.scripting.xslt.XSLTResponseWriter
+    -Dsolr.pki.sendVersion=v1
+    -Dsolr.pki.acceptVersions=v1,v2
   solrLogLevel: WARN
   updateStrategy:
     method: Managed


### PR DESCRIPTION
New environment variables:

Required for [XSLT ResponseWriter](https://solr.apache.org/guide/solr/latest/query-guide/response-writers.html#xslt-response-writer) to function in v9
```
    -Dsolr.modules=scripting
     -Dsolrxsltloc=solr.scripting.xslt.XSLTResponseWriter
```

Step 1 of [Rolling Upgrade](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#rolling-upgrades)
```
     -Dsolr.pki.sendVersion=v1
     -Dsolr.pki.acceptVersions=v1,v2
```