### PR TITLE
Upgrade Prod v9.1.1

### DIFF
--- a/monitoring/prom-exporter.yml
+++ b/monitoring/prom-exporter.yml
@@ -24,3 +24,6 @@ spec:
         name: pkcs12-password-secret-prod
         key: password-key
   numThreads: 6
+  image:
+    repository: solr
+    tag: 9.1.1

--- a/solr/deployment.yml
+++ b/solr/deployment.yml
@@ -68,9 +68,15 @@ spec:
   replicas: 3
   solrImage:
     repository: solr
-    tag: 8.11.1
+    tag: 9.1.1
   solrJavaMem: -Xms3g -Xmx3g
-  solrOpts: "-Dlog4j2.formatMsgNoLookups=true -Dsolr.cloud.client.stallTime=30000 -Dsolr.environment=prod"
+  solrOpts: >
+    -Dsolr.cloud.client.stallTime=30000
+    -Dsolr.environment=prod
+    -Dsolr.modules=scripting
+    -Dsolrxsltloc=solr.scripting.xslt.XSLTResponseWriter
+    -Dsolr.pki.sendVersion=v1
+    -Dsolr.pki.acceptVersions=v1,v2
   solrLogLevel: WARN
   updateStrategy:
     managed:


### PR DESCRIPTION
[Trello](https://trello.com/c/mYBnty6X)
This contains the solr manifest changes necessary for a v9 upgrade. Currently expecting a 9.1.1 release of Solr before attempting upgrade.

NOTE: For Prod, this will end up being a 3 step process to get the PKI Auth working see [here](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html#rolling-upgrades)

Step 2: Change solrOpt to `-Dsolr.pki.sendVersion=v2`
Step 3: Change solrOpt to `-Dsolr.pki.acceptVersions=v2`
